### PR TITLE
Added blockstyles new format license key support

### DIFF
--- a/Licensing/License.php
+++ b/Licensing/License.php
@@ -95,10 +95,11 @@ class License {
 			return $api_params;
 		}
 
-		switch ( strstr( $api_params['license'], '_', true ) ) {
-			case 'EABS':
-				$api_params['item_id'] = 377;
-				break;
+		// License key format will be EABS_[product_id]_[license_key] and also support fallback EABS_[license_key]
+		if ( preg_match( '/EABS_(.*?)_/', $api_params['license'], $match ) === 1 ) {
+			$api_params['item_id'] = ! empty( $match[1] ) ? $match[1] : 377;
+		} elseif ( strstr( $api_params['license'], '_', true ) === 'EABS' ) {
+			$api_params['item_id'] = 377; // This is fallback product id for old blockstyle keys.
 		}
 
 		return $api_params;


### PR DESCRIPTION
@royboy789 
We added the fallback product item id as `377` because need to support the old keys.
Even if we will provide new keys (with a new format) to the old customer that will make an issue for them because they can't deactivate the license until we support the old format - `EABS_[license_key]`