### PR TITLE
Fix PHP 8.2+ deprecated dynamic property warning

### DIFF
--- a/Licensing/License.php
+++ b/Licensing/License.php
@@ -12,6 +12,7 @@ use stdClass;
 /**
  * EDD Software Licensing Class
  */
+#[\AllowDynamicProperties]
 class License {
 
 	/**

--- a/Licensing/License.php
+++ b/Licensing/License.php
@@ -12,7 +12,7 @@ use stdClass;
 /**
  * EDD Software Licensing Class
  */
-#[\AllowDynamicProperties]
+#[AllowDynamicProperties]
 class License {
 
 	/**


### PR DESCRIPTION
Add #[AllowDynamicProperties] attribute to License class to prevent 'Creation of dynamic property' deprecation warnings in PHP 8.2+.